### PR TITLE
Disable spatial dropouts during evaluation for ENet-Label

### DIFF
--- a/ENet-Label-Torch/testLane.lua
+++ b/ENet-Label-Torch/testLane.lua
@@ -21,6 +21,18 @@ if opt.smooth then
    offset = 1
 end
 
+-- Disable spatial dropouts for evaluation
+dropout_nodes, container_nodes = model:findModules('nn.SpatialDropout')
+for i = 1, #dropout_nodes do
+  -- Search the container for the current dropout node
+  for j = 1, #(container_nodes[i].modules) do
+    if container_nodes[i].modules[j] == dropout_nodes[i] then
+      -- Manually set dropout probability to 0
+      container_nodes[i].modules[j].p = 0
+    end
+  end
+end
+
 print(model)
 local valLoader = DataLoader.create(opt)
 print('data loaded')


### PR DESCRIPTION
It looks like the spatial dropouts are not disabled properly during evaluation. Looking at the source code [here](https://github.com/torch/nn/blob/master/SpatialDropout.lua#L11), it doesn't seem that spatial dropouts are disabled when `self.train = false`. I had to manually disable them by setting the probability to 0. Feel free to merge this PR if dropouts should be disabled at evaluation time.