### PR TITLE
accelerate lane evaluation by openmp with 20x

### DIFF
--- a/ERFNet-CULane-PyTorch/tools/lane_evaluation/Makefile
+++ b/ERFNet-CULane-PyTorch/tools/lane_evaluation/Makefile
@@ -15,7 +15,7 @@ BUILD_DIR := build
 CXX ?= g++
 BUILD_DIR ?= ./build
 
-LIBRARIES += opencv_core opencv_highgui opencv_imgproc
+LIBRARIES += opencv_core opencv_highgui opencv_imgproc opencv_imgcodecs
 
 CXXFLAGS += $(COMMON_FLAGS) $(foreach includedir,$(INCLUDE_DIRS),-I$(includedir))
 LDFLAGS +=  $(COMMON_FLAGS) $(foreach includedir,$(LIBRARY_DIRS),-L$(includedir)) $(foreach library,$(LIBRARIES),-l$(library))

--- a/ERFNet-CULane-PyTorch/tools/lane_evaluation/include/counter.hpp
+++ b/ERFNet-CULane-PyTorch/tools/lane_evaluation/include/counter.hpp
@@ -5,6 +5,7 @@
 #include "hungarianGraph.hpp"
 #include <iostream>
 #include <algorithm>
+#include <tuple>
 #include <vector>
 #include <opencv2/core/core.hpp>
 
@@ -26,9 +27,12 @@ class Counter
 		long getTP(void);
 		long getFP(void);
 		long getFN(void);
+		void setTP(long);
+		void setFP(long);
+		void setFN(long);
 		// direct add tp, fp, tn and fn
 		// first match with hungarian
-		vector<int> count_im_pair(const vector<vector<Point2f> > &anno_lanes, const vector<vector<Point2f> > &detect_lanes);
+		tuple<vector<int>, long, long, long, long> count_im_pair(const vector<vector<Point2f> > &anno_lanes, const vector<vector<Point2f> > &detect_lanes);
 		void makeMatch(const vector<vector<double> > &similarity, vector<int> &match1, vector<int> &match2);
 
 	private:

--- a/ERFNet-CULane-PyTorch/tools/lane_evaluation/include/lane_compare.hpp
+++ b/ERFNet-CULane-PyTorch/tools/lane_evaluation/include/lane_compare.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include <iostream>
 #include <opencv2/core/core.hpp>
+#include <opencv2/imgproc.hpp>
 
 using namespace std;
 using namespace cv;

--- a/ERFNet-CULane-PyTorch/tools/lane_evaluation/src/counter.cpp
+++ b/ERFNet-CULane-PyTorch/tools/lane_evaluation/src/counter.cpp
@@ -43,20 +43,33 @@ long Counter::getFN(void)
 	return fn;
 }
 
-vector<int> Counter::count_im_pair(const vector<vector<Point2f> > &anno_lanes, const vector<vector<Point2f> > &detect_lanes)
+void Counter::setTP(long value) 
+{
+	tp = value;
+}
+
+void Counter::setFP(long value)
+{
+  fp = value;
+}
+
+void Counter::setFN(long value)
+{
+	fn = value;
+}
+
+tuple<vector<int>, long, long, long, long> Counter::count_im_pair(const vector<vector<Point2f> > &anno_lanes, const vector<vector<Point2f> > &detect_lanes)
 {
 	vector<int> anno_match(anno_lanes.size(), -1);
 	vector<int> detect_match;
 	if(anno_lanes.empty())
 	{
-		fp += detect_lanes.size();
-		return anno_match;
+		return make_tuple(anno_match, 0, detect_lanes.size(), 0, 0);
 	}
 
 	if(detect_lanes.empty())
 	{
-		fn += anno_lanes.size();
-		return anno_match;
+		return make_tuple(anno_match, 0, 0, 0, anno_lanes.size());
 	}
 	// hungarian match first
 	
@@ -92,10 +105,7 @@ vector<int> Counter::count_im_pair(const vector<vector<Point2f> > &anno_lanes, c
 	}
 	int curr_fn = anno_lanes.size() - curr_tp;
 	int curr_fp = detect_lanes.size() - curr_tp;
-	tp += curr_tp;
-	fn += curr_fn;
-	fp += curr_fp;
-	return anno_match;
+	return make_tuple(anno_match, curr_tp, curr_fp, 0, curr_fn);
 }
 
 


### PR DESCRIPTION
Hi,
Glad to use the lane evaluation tools while a little slow.
There, I implemented a multi-process version by using OpenMP and achieved a 20x acceleration (32 core server).

```bash
# test on ERFNet-Trained Model.
Evaluating the results...
tp: 76427 fp: 27769 fn: 28459
finished process file
precision: 0.733493
recall: 0.728667
Fmeasure: 0.731072
```

The result is identical with the vanilla version.
Best,
KJ